### PR TITLE
Add validation message + fail grunt build in case invalid yaml files found.

### DIFF
--- a/tasks/yaml_validator.js
+++ b/tasks/yaml_validator.js
@@ -35,6 +35,13 @@ module.exports = function yamlValidator(grunt) {
     const validator = new YamlValidatore(options);
     validator.validate(files);
     validator.report();
+    
+    if (validator.inValidFilesCount) {
+      grunt.fail.warn('YAML validation errors found.');
+    } else {
+      var filesCount = files.length;
+      grunt.log.ok(filesCount + ' ' + grunt.util.pluralize(filesCount, 'file/files') + ' lint free.');
+    }
   });
 
 };

--- a/test/fixtures/defaults.yml
+++ b/test/fixtures/defaults.yml
@@ -1,0 +1,1 @@
+test: true

--- a/test/fixtures/logged.yml
+++ b/test/fixtures/logged.yml
@@ -1,0 +1,1 @@
+test: true


### PR DESCRIPTION
With this update, if all yaml files are valid, it will print:

````sh
>> 1 file lint free.
````

Naturally the message will be based on amount of file and it is consistent with other grunt linting plugins.

ALSO: as part of this change, in case of invalid yaml found, the grunt buld will fail.
Again, consistent with other linting plugins.